### PR TITLE
Remove unnecessary path from Composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,8 @@
             "@test:style",
             "@test:unit"
         ],
-        "test:style": "@php vendor/bin/php-cs-fixer fix --config=.php_cs --allow-risky=yes --dry-run --diff --verbose",
-        "test:unit": "@php vendor/bin/phpunit",
-        "fix:style": "@php vendor/bin/php-cs-fixer fix --config=.php_cs --allow-risky=yes --diff --verbose"
+        "test:style": "php-cs-fixer fix --config=.php_cs --allow-risky=yes --dry-run --diff --verbose",
+        "test:unit": "phpunit",
+        "fix:style": "php-cs-fixer fix --config=.php_cs --allow-risky=yes --diff --verbose"
     }
 }


### PR DESCRIPTION
The `@php vendor/bin/` is actually completely unnecessary, because Composer will automatically push the `vendor/bin` directory to the top of the `$PATH` environment variable before executing any of its scripts. This means we can just reference the script name(s), and they'll work out of the box!

Ref: https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands