### PR TITLE
Add artisan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ You can install the package via composer:
 composer require goldspecdigital/laravel-eloquent-uuid:^v6.0
 ```
 
+If you want to use command `php artisan uuid:make:model` you should register
+```php
+/*
+ * Package Service Providers...
+ */
+GoldSpecDigital\LaravelEloquentUUID\UuidServiceProvider::class,
+```
+in `config/app.php`.
+
 ## Usage
 
 When creating a Eloquent model, instead of extending the standard Laravel model

--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,12 @@
         "test:style": "php-cs-fixer fix --config=.php_cs --allow-risky=yes --dry-run --diff --verbose",
         "test:unit": "phpunit",
         "fix:style": "php-cs-fixer fix --config=.php_cs --allow-risky=yes --diff --verbose"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "GoldSpecDigital\\LaravelEloquentUUID\\UuidServiceProvider"
+            ]
+        }
     }
 }

--- a/src/Console/Stubs/UUID.stub
+++ b/src/Console/Stubs/UUID.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace DummyNamespace;
+
+use GoldSpecDigital\LaravelEloquentUUID\Database\Eloquent\Model;
+
+class DummyClass extends Model
+{
+    //
+}

--- a/src/Console/UuidModelCommand.php
+++ b/src/Console/UuidModelCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace GoldSpecDigital\LaravelEloquentUUID\Console;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Console\GeneratorCommand;
+
+class UuidModelCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'uuid:make:model';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new UUID Model';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'UUID Model';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return realpath(__DIR__ . '/Stubs/UUID.stub');
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Models';
+    }
+}

--- a/src/Console/UuidModelCommand.php
+++ b/src/Console/UuidModelCommand.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GoldSpecDigital\LaravelEloquentUUID\Console;
 
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Console\GeneratorCommand;
 
 class UuidModelCommand extends GeneratorCommand
@@ -41,11 +42,11 @@ class UuidModelCommand extends GeneratorCommand
     /**
      * Get the default namespace for the class.
      *
-     * @param  string  $rootNamespace
+     * @param string $rootNamespace
      * @return string
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace.'\Models';
+        return $rootNamespace . '\Models';
     }
 }

--- a/src/UuidServiceProvider.php
+++ b/src/UuidServiceProvider.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GoldSpecDigital\LaravelEloquentUUID;
 
-use Illuminate\Support\ServiceProvider;
 use GoldSpecDigital\LaravelEloquentUUID\Console\UuidModelCommand;
+use Illuminate\Support\ServiceProvider;
 
 class UuidServiceProvider extends ServiceProvider
 {

--- a/src/UuidServiceProvider.php
+++ b/src/UuidServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GoldSpecDigital\LaravelEloquentUUID;
+
+use Illuminate\Support\ServiceProvider;
+use GoldSpecDigital\LaravelEloquentUUID\Console\UuidModelCommand;
+
+class UuidServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                UuidModelCommand::class,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
Closes goldspecdigital/laravel-eloquent-uuid#2

This is my contribution in creating artisan command.
Although there seems to be issues with package auto-discovery.
It cannot discover the service provider needed to register package command.
The workaround is to register `GoldSpecDigital\LaravelEloquentUUID\UuidServiceProvider::class,` in `config/app.php`.