### PR TITLE
Add ModelTrait for more reusability

### DIFF
--- a/src/Database/Eloquent/Model.php
+++ b/src/Database/Eloquent/Model.php
@@ -4,32 +4,18 @@ declare(strict_types=1);
 
 namespace GoldSpecDigital\LaravelEloquentUUID\Database\Eloquent;
 
-use Exception;
 use Illuminate\Database\Eloquent\Model as BaseModel;
-use Ramsey\Uuid\Uuid;
 
 abstract class Model extends BaseModel
 {
+    use ModelTrait;
+
     /**
      * The "type" of the auto-incrementing ID.
      *
      * @var string
      */
     protected $keyType = 'string';
-
-    /**
-     * Indicates if the IDs are UUIDs.
-     *
-     * @var bool
-     */
-    protected $keyIsUuid = true;
-
-    /**
-     * The UUID version to use.
-     *
-     * @var int
-     */
-    protected $uuidVersion = 4;
 
     /**
      * Indicates if the IDs are auto-incrementing.
@@ -55,35 +41,4 @@ abstract class Model extends BaseModel
         'updated_at' => 'datetime',
         'deleted_at' => 'datetime',
     ];
-
-    /**
-     * The "booting" method of the model.
-     */
-    protected static function boot(): void
-    {
-        parent::boot();
-
-        static::creating(function (self $model): void {
-            // Automatically generate a UUID if using them, and not provided.
-            if ($model->keyIsUuid && empty($model->{$model->getKeyName()})) {
-                $model->{$model->getKeyName()} = $model->generateUuid();
-            }
-        });
-    }
-
-    /**
-     * @throws \Exception
-     * @return string
-     */
-    protected function generateUuid(): string
-    {
-        switch ($this->uuidVersion) {
-            case 1:
-                return Uuid::uuid1()->toString();
-            case 4:
-                return Uuid::uuid4()->toString();
-        }
-
-        throw new Exception("UUID version [{$this->uuidVersion}] not supported.");
-    }
 }

--- a/src/Database/Eloquent/ModelTrait.php
+++ b/src/Database/Eloquent/ModelTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GoldSpecDigital\LaravelEloquentUUID\Database\Eloquent;
+
+use Exception;
+use Ramsey\Uuid\Uuid;
+
+trait ModelTrait
+{
+    /**
+     * Indicates if the IDs are UUIDs.
+     *
+     * @var bool
+     */
+    protected $keyIsUuid = true;
+
+    /**
+     * The UUID version to use.
+     *
+     * @var int
+     */
+    protected $uuidVersion = 4;
+
+    /**
+     * The "booting" method of the model.
+     */
+    protected static function bootModelTrait(): void
+    {
+        static::creating(function (self $model): void {
+            // Automatically generate a UUID if using them, and not provided.
+            if ($model->keyIsUuid && empty($model->{$model->getKeyName()})) {
+                $model->{$model->getKeyName()} = $model->generateUuid();
+            }
+        });
+    }
+
+    /**
+     * @throws \Exception
+     * @return string
+     */
+    protected function generateUuid(): string
+    {
+        switch ($this->uuidVersion) {
+            case 1:
+                return Uuid::uuid1()->toString();
+            case 4:
+                return Uuid::uuid4()->toString();
+        }
+
+        throw new Exception("UUID version [{$this->uuidVersion}] not supported.");
+    }
+}


### PR DESCRIPTION
Greetings, I've just started to use this package for my new project that use uuid for its models. It's working great until I need to implement uuid on a model that extends from another package.

The solution that I've done is to copy the entire `GoldSpecDigital\LaravelEloquentUUID\Database\Eloquent\Model` class properties and methods to that mentioned model. I think this it's better to add a trait so my class would just use that trait.

Best regard,
Firman