### PR TITLE
Laravel 8 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ version of Laravel you have installed:
 | `v5.8.*` | `v1.*` |
 | `v6.*` | `v6.*` |
 | `v7.*` | `v7.*` |
+| `v8.*` | `v8.*` |
 
 You can install the package via composer:
 
 ```bash
-composer require goldspecdigital/laravel-eloquent-uuid:^7.0
+composer require goldspecdigital/laravel-eloquent-uuid:^8.0
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
         }
     },
     "require": {
-        "php": "^7.2.5",
-        "laravel/framework": "^7.0"
+        "php": "^7.3",
+        "laravel/framework": "^8.0"
     },
     "require-dev": {
         "ext-pdo": "*",
         "friendsofphp/php-cs-fixer": "^2.15",
-        "orchestra/testbench": "^5.0",
+        "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^8.4"
     },
     "config": {


### PR DESCRIPTION
I've just gone ahead and bumped the versions since I'd like to have this as soon as possible.

This PR updates the package to accept Laravel 8, along with that goes the breaking change of requiring at least PHP 7.3. I've not changed the Travis config as I have no experience there, this will probably cause the PR to fail though. Just let me know how you want to handle that.

This should also close #34.