### PR TITLE
add UUID v6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ echo $model->id; // 04d7f995-ef33-4870-a214-4e21c51ff76e
 ### Specifying UUID versions
 
 By default, `v4` UUIDs will be used for your models. However, you can also 
-specify `v1` UUIDs to be used by setting the following property/method on your 
+specify `v1` or `v6` UUIDs to be used by setting the following property/method on your 
 model:
 
 #### When extending the class
@@ -218,6 +218,22 @@ class BlogPost extends Model
     }
 }
 ```
+
+#### About `v6`
+> Version 6, ordered-time UUIDs are an experimental feature based on an Internet-Draft
+> under review at the IETF. While the basic layout is not expected to change, be aware
+> that the draft is a moving target. If there are significant changes to the layout,
+> ramsey/uuid will attempt to maintain backward compatibility but cannot guarantee it.
+
+Version 6 UUIDs solve two problems that have long existed with the use of version 1 UUIDs:
+
+- Scattered database records
+- Inability to sort by an identifier in a meaningful way (i.e., insert order)
+
+To overcome these issues, we need the ability to generate UUIDs that are monotonically
+increasing while still providing all the benefits of version 1 UUIDs.
+
+[Read more here](https://uuid.ramsey.dev/en/4.3.0/nonstandard/version6.html)
 
 #### Support for `v3` and `v5`
 

--- a/src/Database/Eloquent/Uuid.php
+++ b/src/Database/Eloquent/Uuid.php
@@ -53,6 +53,8 @@ trait Uuid
                 return RamseyUuid::uuid1()->toString();
             case 4:
                 return RamseyUuid::uuid4()->toString();
+            case 6:
+                return RamseyUuid::uuid6()->toString();
         }
 
         throw new Exception("UUID version [{$this->uuidVersion()}] not supported.");

--- a/tests/Models/TestModelExtendingClassWithUuid6.php
+++ b/tests/Models/TestModelExtendingClassWithUuid6.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GoldSpecDigital\LaravelEloquentUUID\Tests\Models;
+
+use GoldSpecDigital\LaravelEloquentUUID\Database\Eloquent\Model;
+
+class TestModelExtendingClassWithUuid6 extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'test_model_with_uuids';
+
+
+    /**
+     * The UUID version to use.
+     *
+     * @var int
+     */
+    protected int $uuidVersion = 1;
+}

--- a/tests/Models/TestModelExtendingClassWithUuid6.php
+++ b/tests/Models/TestModelExtendingClassWithUuid6.php
@@ -21,5 +21,5 @@ class TestModelExtendingClassWithUuid6 extends Model
      *
      * @var int
      */
-    protected int $uuidVersion = 1;
+    protected int $uuidVersion = 6;
 }

--- a/tests/Models/TestModelExtendingClassWithoutUuid6.php
+++ b/tests/Models/TestModelExtendingClassWithoutUuid6.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GoldSpecDigital\LaravelEloquentUUID\Tests\Models;
+
+use GoldSpecDigital\LaravelEloquentUUID\Database\Eloquent\Model;
+
+class TestModelExtendingClassWithoutUuid6 extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'test_model_without_uuids';
+
+    /**
+     * Indicates if the IDs are UUIDs.
+     *
+     * @var bool
+     */
+    protected bool $keyIsUuid = false;
+
+    /**
+     * The UUID version to use.
+     *
+     * @var int
+     */
+    protected int $uuidVersion = 6;
+}

--- a/tests/Models/TestModelUsingTraitWithUuid6.php
+++ b/tests/Models/TestModelUsingTraitWithUuid6.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GoldSpecDigital\LaravelEloquentUUID\Tests\Models;
+
+use GoldSpecDigital\LaravelEloquentUUID\Database\Eloquent\Uuid;
+use Illuminate\Database\Eloquent\Model;
+
+class TestModelUsingTraitWithUuid6 extends Model
+{
+    use Uuid;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'test_model_with_uuids';
+
+    /**
+     * The "type" of the auto-incrementing ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The UUID version to use.
+     *
+     * @return int
+     */
+    protected function uuidVersion(): int
+    {
+        return 6;
+    }
+}

--- a/tests/Models/TestModelUsingTraitWithoutUuid6.php
+++ b/tests/Models/TestModelUsingTraitWithoutUuid6.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GoldSpecDigital\LaravelEloquentUUID\Tests\Models;
+
+use GoldSpecDigital\LaravelEloquentUUID\Database\Eloquent\Uuid;
+use Illuminate\Database\Eloquent\Model;
+
+class TestModelUsingTraitWithoutUuid6 extends Model
+{
+    use Uuid;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'test_model_without_uuids';
+
+    /**
+     * The "type" of the auto-incrementing ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * Indicates if the IDs are UUIDs.
+     *
+     * @return bool
+     */
+    protected function keyIsUuid(): bool
+    {
+        return false;
+    }
+
+    /**
+     * The UUID version to use.
+     *
+     * @return int
+     */
+    protected function uuidVersion(): int
+    {
+        return 6;
+    }
+}


### PR DESCRIPTION
[Although V6 is still experimental](https://uuid.ramsey.dev/en/4.3.0/nonstandard/version6.html), it looks very promising
and it would be great to add support for it.

This is nor a breaking change - v4 is still a default, nor a huge one - only added one more case.

I know there are other ways to achieve this, but please consider this option. Thanks!